### PR TITLE
Added missing gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ gem 'bundler', '>= 1.7.0'
 gem 'sinatra', require: 'sinatra/base'
 gem 'sinatra-asset-pipeline', require: 'sinatra/asset_pipeline'
 
+gem 'execjs'
+gem "therubyracer"
+
 gem 'uglifier'
 gem 'slim'
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'sinatra', require: 'sinatra/base'
 gem 'sinatra-asset-pipeline', require: 'sinatra/asset_pipeline'
 
 gem 'execjs'
-gem "therubyracer"
+gem 'therubyracer'
 
 gem 'uglifier'
 gem 'slim'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     execjs (2.3.0)
     hike (1.2.3)
     json (1.8.2)
+    libv8 (3.16.14.17-x86_64-linux)
     multi_json (1.10.1)
     rack (1.6.0)
     rack-protection (1.5.3)
@@ -17,6 +18,7 @@ GEM
       rails-assets-jquery (>= 1.9.1)
     rails-assets-jquery (2.1.3)
     rake (10.4.2)
+    ref (2.0.0)
     sass (3.4.12)
     sinatra (1.4.5)
       rack (~> 1.4)
@@ -44,6 +46,9 @@ GEM
       sprockets (~> 2.0)
       tilt (~> 1.1)
     temple (0.6.10)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     tilt (1.4.1)
     uglifier (2.7.0)
       execjs (>= 0.3.0)
@@ -54,9 +59,14 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (>= 1.7.0)
+  execjs
   rails-assets-bootstrap!
   rails-assets-jquery!
   sinatra
   sinatra-asset-pipeline
   slim
+  therubyracer
   uglifier
+
+BUNDLED WITH
+   1.14.5

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ gem 'bundler', '>= 1.7.0'
 gem 'sinatra', require: 'sinatra/base'
 gem 'sinatra-asset-pipeline', require: 'sinatra/asset_pipeline'
 
+gem 'execjs'
+gem 'therubyracer'
+
 gem 'uglifier'
 gem 'slim'
 


### PR DESCRIPTION
Every time I've tried to run `bundle exec rackup -p 4000`, I've got this message:

```
Gem Load Error is: Could not find a JavaScript runtime
```

DuckDuckGoing a little bit, I've found the solution: add missing gems to make uglify work properly.